### PR TITLE
Fix race conditon on PyQt Text Output

### DIFF
--- a/python/text_output.py
+++ b/python/text_output.py
@@ -20,14 +20,12 @@
 # Boston, MA 02110-1301, USA.
 #
 import numpy
-from gnuradio import gr;
-import pylab
-import numpy
+from gnuradio import gr
 from PyQt4 import Qt, QtCore, QtGui
 import pmt
 
 class text_output(gr.sync_block, QtGui.QTextEdit):
-    __pyqtSignals__ = ("updateText(int)")
+    __pyqtSignals__ = ("updateText(QString)")
     def __init__(self, blkname="text_output", label="", *args):
         gr.sync_block.__init__(self,blkname,[],[])
         QtGui.QTextEdit.__init__(self, *args)
@@ -35,17 +33,15 @@ class text_output(gr.sync_block, QtGui.QTextEdit):
         self.set_msg_handler(pmt.intern("pdus"), self.handle_input);
         # connect the plot callback signal
         QtCore.QObject.connect(self,
-                       QtCore.SIGNAL("updateText(int)"),
-                       self.updateText)
+                       QtCore.SIGNAL("updateText(QString)"),
+                       self,
+                       QtCore.SLOT("append(QString)"))
 
     def handle_input(self, msg):
-        vec = pmt.cdr(msg);
-        nvec = pmt.to_python(vec);
-        self.s = str(nvec.tostring());
-        self.emit(QtCore.SIGNAL("updateText(int)"), 0)
-
-    def updateText(self, a):
-        self.append(self.s);
+        vec = pmt.cdr(msg)
+        nvec = pmt.to_python(vec)
+        s = str(nvec.tostring())
+        self.emit(QtCore.SIGNAL("updateText(QString)"), s)
 
     def work(self, input_items, output_items):
         pass


### PR DESCRIPTION
When receiving multiple messages in a short amount of time, the updateText callback is not triggered between every handle_input call.
This causes the same message to be displayed multiple times because self.s is overwritten.

This patch fixes the race condition in this class but I suppose some other blocks may have the same problem.

(+ remove semicolons, they were driving me crazy :) )
