### PR TITLE
Remove RTLD_GLOBAL hack for swig

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -23,24 +23,6 @@ This is the GNU Radio PYQT module. Place your Python package
 description here (python/__init__.py).
 '''
 
-# ----------------------------------------------------------------
-# Temporary workaround for ticket:181 (swig+python problem)
-import sys
-_RTLD_GLOBAL = 0
-try:
-    from dl import RTLD_GLOBAL as _RTLD_GLOBAL
-except ImportError:
-    try:
-	from DLFCN import RTLD_GLOBAL as _RTLD_GLOBAL
-    except ImportError:
-	pass
-
-if _RTLD_GLOBAL != 0:
-    _dlopenflags = sys.getdlopenflags()
-    sys.setdlopenflags(_dlopenflags|_RTLD_GLOBAL)
-# ----------------------------------------------------------------
-
-
 # import swig generated symbols into the pyqt namespace
 #from pyqt_swig import *
 
@@ -75,9 +57,3 @@ from file_open import *
 from set_title import *
 from table import *
 from dict_ui_source import *
-
-# ----------------------------------------------------------------
-# Tail of workaround
-if _RTLD_GLOBAL != 0:
-    sys.setdlopenflags(_dlopenflags)      # Restore original flags
-# ----------------------------------------------------------------


### PR DESCRIPTION
If pyqt is imported prior to gr-qtgui being imported, usage of QwtPlot-based gr-qtgui widgets will fail at runtime with:

```
Object::connect: No such signal QwtPlotPicker::selected(const QPointF &)
Segmentation fault (core dumped)
```

This error is caused by the ``_RTLD_GLOBAL`` hack used by older versions of gr-modtool. The import order which exposes this problem may be generated by GRC in the specific circumstance of gr-pyqt being used inside a hierarchical block which has an ID that is alphabetically before ``gr-``.

I haven't been able to find any reason to keep the hack around, and it isn't in most other current OOT modules. The specific platform I'm encountering the error on is GNU Radio v3.7.11 on Ubuntu 16.04.2 LTS, with up-to-date apt versions of Qt, PyQT4, etc.